### PR TITLE
chore(next.config.js): enable production browser source maps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
       },
     ],
   },
+  productionBrowserSourceMaps: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Enabling production browser source maps allows for better debugging and error tracking in a production environment.